### PR TITLE
Moving nodeLabel to JenkinsFile

### DIFF
--- a/src/ni/vsbuild/PipelineExecutor.groovy
+++ b/src/ni/vsbuild/PipelineExecutor.groovy
@@ -2,8 +2,8 @@ package ni.vsbuild
 
 class PipelineExecutor implements Serializable {
 
-   static void execute(script, List<String> lvVersions, List<String> dependencies = []) {
-      def pipelineInformation = new PipelineInformation('veristand', lvVersions, dependencies)
+   static void execute(script, String nodeLabel, List<String> lvVersions, List<String> dependencies = []) {
+      def pipelineInformation = new PipelineInformation(nodeLabel, lvVersions, dependencies)
       pipelineInformation.printInformation(script)
 
       def pipeline = new Pipeline(script, pipelineInformation)


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Pipeline Executor now expects the first argument to be the Label of the node.

### Why should this Pull Request be merged?

This would allow for building arbitrary, non-veristand projects with this system.

### What testing has been done?

Change is minimal. This will require, however, updating Jenkinsfiles on other systems to add this to the Executor call. 
