### PR TITLE
Moving nodeLabel to Jenkinsfile (#12)

### DIFF
--- a/src/ni/vsbuild/Pipeline.groovy
+++ b/src/ni/vsbuild/Pipeline.groovy
@@ -34,7 +34,7 @@ class Pipeline implements Serializable {
       def withArchiveStage() {
          stages << new Archive(script, buildConfiguration, lvVersion)
       }
-      
+
       def withPackageStage() {
          stages << new Package(script, buildConfiguration, lvVersion)
       }
@@ -50,7 +50,7 @@ class Pipeline implements Serializable {
             script.env.BRANCH_NAME.startsWith("hotfix"))
       }
 
-      def buildPipeline() {         
+      def buildPipeline() {
          if(buildConfiguration.codegen || buildConfiguration.projects) {
             withCodegenStage()
          }
@@ -88,8 +88,13 @@ class Pipeline implements Serializable {
          // need to bind the variable before the closure - can't do 'for (version in lvVersions)'
          def lvVersion = version
 
+         String nodeLabel = lvVersion
+         if (pipelineInformation.nodeLabel?.trim()) {
+            nodeLabel = "$nodeLabel && ${pipelineInformation.nodeLabel}"
+         }
+
          builders[lvVersion] = {
-            script.node("${pipelineInformation.nodeLabel} && $lvVersion") {
+            script.node(nodeLabel) {
                setup(lvVersion)
 
                def configuration = BuildConfiguration.load(script, JSON_FILE)

--- a/src/ni/vsbuild/PipelineExecutor.groovy
+++ b/src/ni/vsbuild/PipelineExecutor.groovy
@@ -2,11 +2,14 @@ package ni.vsbuild
 
 class PipelineExecutor implements Serializable {
 
-   static void execute(script, List<String> lvVersions, List<String> dependencies = []) {
-      def pipelineInformation = new PipelineInformation('veristand', lvVersions, dependencies)
+   static void execute(script, String nodeLabel, List<String> lvVersions, List<String> dependencies = []) {
+      def pipelineInformation = new PipelineInformation(nodeLabel, lvVersions, dependencies)
       pipelineInformation.printInformation(script)
-
       def pipeline = new Pipeline(script, pipelineInformation)
       pipeline.execute()
    }
+   
+   static void execute(script, List<String> lvVersions, List<String> dependencies = []) {
+      execute(script, '', lvVersions, dependencies)
+   } 
 }

--- a/src/ni/vsbuild/PipelineInformation.groovy
+++ b/src/ni/vsbuild/PipelineInformation.groovy
@@ -13,6 +13,11 @@ class PipelineInformation implements Serializable {
    }
 
    public void printInformation(script) {
-      script.echo "Pipeline will be run for LV versions $lvVersions and will execute on node(s) with label \'$nodeLabel\'."
-   }
+      String infoString = "Pipeline will be run for LV versions $lvVersions"
+      if(nodeLabel?.trim()) {
+         infoString = "$infoString and will execute on node(s) with label \'$nodeLabel\'."
+      }
+      
+      script.echo "$infoString"
+   }  
 }


### PR DESCRIPTION
* Moving nodeLabel to JenkinsFile

The nodeLabel is now effectively optional. If there is no nodeLabel passed to the executor, it will use an empty string. On an empty string, it will run it on the node with the correct LabVIEW version.

[ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

TODO: Include high-level description of the changes in this pull request.

### Why should this Pull Request be merged?

TODO: Justify why this contribution should be part of the project.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
