### PR TITLE
Add VITester and vs-test-tools Functionality

### DIFF
--- a/src/ni/vsbuild/steps/LvVITesterStep.groovy
+++ b/src/ni/vsbuild/steps/LvVITesterStep.groovy
@@ -12,6 +12,7 @@ class LvVITesterStep extends LvProjectStep {
    }
 
    void executeStep(BuildConfiguration configuration) {
+      script.cloneVSTestTools()
       script.lvVITester(Test_path, lvVersion)
    }
 }

--- a/vars/cloneVSTestTools.groovy
+++ b/vars/cloneVSTestTools.groovy
@@ -3,6 +3,21 @@ def call(){
 
    def organization = getComponentParts()['organization']
    def branch = env."library.vs-test-tools.version"
-   buildToolsDir = cloneRepo("https://github.com/$organization/niveristand-custom-device-testing-tools", branch)
+
+  repo = "https://github.com/$organization/niveristand-custom-device-testing-tools"
+  echo "Cloning $repo to $branch directory."
+  testToolsDir = "..\\" + repo.tokenize("/").last()
+
+  echo "Over-writing old test tools at $testToolsDir"
+  bat "if exist \"$testToolsDir\" rmdir /S /Q \"$testToolsDir\""
+  bat "mkdir $testToolsDir"
+
+  if(!branch  || branch == null){
+     branch = 'master'
+  }
+
+  dir(testToolsDir){
+     git url: repo, branch: branch
+  }
    return testToolsDir
 }

--- a/vars/cloneVSTestTools.groovy
+++ b/vars/cloneVSTestTools.groovy
@@ -1,0 +1,8 @@
+def call(){
+   echo 'Cloning vs test tools to workspace.'
+
+   def organization = getComponentParts()['organization']
+   def branch = env."library.vs-test-tools.version"
+   buildToolsDir = cloneRepo("https://github.com/$organization/niveristand-custom-device-testing-tools", branch)
+   return testToolsDir
+}

--- a/vars/lvVITester.groovy
+++ b/vars/lvVITester.groovy
@@ -1,4 +1,5 @@
 def call(Test_path, lvVersion){
    echo "Running VITester."
-   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\" -AdditionalOperationDirectory \"$WORKSPACE\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
+   masterDirectory = WORKSPACE.substring(0, WORKSPACE.lastIndexOf("\\"))
+   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\" -AdditionalOperationDirectory \"$masterDirectory\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
 }

--- a/vars/lvVITester.groovy
+++ b/vars/lvVITester.groovy
@@ -1,5 +1,5 @@
 def call(Test_path, lvVersion){
    echo "Running VITester."
-   masterDirectory = WORKSPACE.substring(0, WORKSPACE.lastIndexOf("\\"))
-   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\" -AdditionalOperationDirectory \"$masterDirectory\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
+   branchDirectory = WORKSPACE.substring(0, WORKSPACE.lastIndexOf("\\"))
+   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\" -AdditionalOperationDirectory \"$branchDirectory\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
 }

--- a/vars/lvVITester.groovy
+++ b/vars/lvVITester.groovy
@@ -1,4 +1,4 @@
 def call(Test_path, lvVersion){
-   echo "MBILYK: Running VITester."
-   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\"" -AdditionalOperationDirectory \"$WORKSPACE\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
+   echo "Running VITester."
+   labviewcli("-OperationName RunVITester -TestPath \"$WORKSPACE\\$Test_path\" -AdditionalOperationDirectory \"$WORKSPACE\\niveristand-custom-device-testing-tools\\RunVITester\"", lvVersion)
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-custom-device-build-tools/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This adds the ability to use VITester along with the vs-test-tools in a Jenkins pipeline in order to test VeriStand Custom Devices.

As it stands right now, it is only able to run a single test in VI Tester.

### Why should this Pull Request be merged?
This is part of an effort to ensure that our VS ecosystem is healthy. By adding the ability to test custom devices, we are able to increase the quality of edits to the custom devices in the open source ecosystem.

### What testing has been done?
I created a dummy custom device with a simple loopback in order to ensure that VI tester could be used.